### PR TITLE
Separate metrics gathering to multiple cron jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,15 @@ RUN set -xe; \
     && curl https://raw.githubusercontent.com/cloudve/gxadmin/master/gxadmin > /usr/bin/gxadmin \
     && chmod +x /usr/bin/gxadmin \
     && apt-get autoremove -y && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* \
+    && adduser --system --group $APP_USER;
 
-ADD ./cron.d/ /opt/galaxy/cron.d/
+ADD --chown=gxadmin:gxadmin ./cron.d/ /opt/galaxy/cron.d/
 
 # Create Galaxy user, group, directory; chown
 RUN set -xe; \
-    adduser --system --group $APP_USER; \
     chmod -R 0644 /opt/galaxy/cron.d/; \
+    chmod -R +x /opt/galaxy/cron.d/; \
     crontab -u $APP_USER /opt/galaxy/cron.d/crontab
 
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Metrics scraper for Galaxy.
 # Uses gxadmin functionality for extracting metrics from the galaxy
 # database and sending them to influxdb.
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APP_USER=gxadmin
 
@@ -18,25 +18,27 @@ ENV INFLUX_PASS ""
 # Install python-virtualenv
 RUN set -xe; \
     apt-get -qq update && apt-get install -y --no-install-recommends \
-        vim \
+        tini \
+        cron \
         ca-certificates \
-        python2.7 \
+        python3.8 \
         curl \
         postgresql-client \
-    && ln -s /usr/bin/python2.7 /usr/bin/python \
+    && ln -s /usr/bin/python3.8 /usr/bin/python \
     && curl https://raw.githubusercontent.com/cloudve/gxadmin/master/gxadmin > /usr/bin/gxadmin \
     && chmod +x /usr/bin/gxadmin \
     && apt-get autoremove -y && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
-ADD ./scripts/gather-metrics.sh /usr/bin/gather-metrics.sh
+ADD ./cron.d/ /opt/galaxy/cron.d/
 
 # Create Galaxy user, group, directory; chown
 RUN set -xe; \
     adduser --system --group $APP_USER; \
-    chmod +x /usr/bin/gather-metrics.sh;
+    chmod -R 0644 /opt/galaxy/cron.d/; \
+    crontab -u $APP_USER /opt/galaxy/cron.d/crontab
 
-USER $APP_USER
+ENTRYPOINT ["/usr/bin/tini", "--"]
 
 # [optional] to run:
-CMD gather-metrics.sh
+CMD cron -f -L 15

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,11 @@ ADD --chown=gxadmin:gxadmin ./cron.d/ /opt/galaxy/cron.d/
 RUN set -xe; \
     chmod -R 0644 /opt/galaxy/cron.d/; \
     chmod -R +x /opt/galaxy/cron.d/; \
+    touch /var/log/cron.log; \
+    chown $APP_USER:$APP_USER /var/log/cron.log; \
     crontab -u $APP_USER /opt/galaxy/cron.d/crontab
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 
 # [optional] to run:
-CMD cron -f -L 15
+CMD tail -f /var/log/cron.log 2> /dev/null & cron -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,9 @@ RUN set -xe; \
         python3.8 \
         curl \
         postgresql-client \
+    && ln -s /usr/bin/python3.8 /usr/bin/python3 \
     && ln -s /usr/bin/python3.8 /usr/bin/python \
-    && curl https://raw.githubusercontent.com/cloudve/gxadmin/master/gxadmin > /usr/bin/gxadmin \
+    && curl -L https://github.com/usegalaxy-eu/gxadmin/releases/latest/download/gxadmin > /usr/bin/gxadmin \
     && chmod +x /usr/bin/gxadmin \
     && apt-get autoremove -y && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* \
@@ -47,4 +48,4 @@ RUN set -xe; \
 ENTRYPOINT ["/usr/bin/tini", "--"]
 
 # [optional] to run:
-CMD /bin/bash -c declare -p | grep -Ev 'BASHOPTS|BASH_VERSINFO|EUID|PPID|SHELLOPTS|UID' > /temp-ram-disk/container.env && tail -f /var/log/cron.log 2> /dev/null & cron -f
+CMD /bin/bash -c declare -p | grep -Ev 'BASHOPTS|BASH_VERSINFO|EUID|PPID|SHELLOPTS|UID|_=|IFS' > /temp-ram-disk/container.env && chown gxadmin:gxadmin /temp-ram-disk/container.env && tail -f /var/log/cron.log 2> /dev/null & cron -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,12 @@ RUN set -xe; \
     chmod -R +x /opt/galaxy/cron.d/; \
     touch /var/log/cron.log; \
     chown $APP_USER:$APP_USER /var/log/cron.log; \
-    crontab -u $APP_USER /opt/galaxy/cron.d/crontab
+    crontab -u $APP_USER /opt/galaxy/cron.d/crontab; \
+    # create location for container env vars which will be passed into cron jobs
+    mkdir /temp-ram-disk; \
+    chown $APP_USER:$APP_USER /temp-ram-disk;
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 
 # [optional] to run:
-CMD tail -f /var/log/cron.log 2> /dev/null & cron -f
+CMD /bin/bash -c declare -p | grep -Ev 'BASHOPTS|BASH_VERSINFO|EUID|PPID|SHELLOPTS|UID' > /temp-ram-disk/container.env && tail -f /var/log/cron.log 2> /dev/null & cron -f

--- a/README.md
+++ b/README.md
@@ -15,18 +15,8 @@ If the specified influx database does not exist, it will be automatically create
 ### How it works
 
 The container runs the gather-metrics script which uses gxadmin provided functionality to
-scrape data and dump the result into the given influxdb.
+scrape data and dump the result into the given influxdb. The data from influxdb can be
+graphed using the existing Grafana dashboards for Galaxy.
 
-You can use a cron job to schedule metrics scraping at a cadence of your choice.
-
-### Ansible for cron job
-
-```yaml
-- name: Create a cron job for gathering stats
-  cron:
-    name: Gather Galaxy Stats
-    job: docker run cloudve/galaxy-metrics-scraper:latest <your_env>
-    minute: 0
-    hour: 0
-    user: "<some_low_privilege_user>"
-```
+Internally, the docker container runs a crontab which will run at minute, hourly, and daily
+schedules to gather various metrics.

--- a/cron.d/cron.daily/galaxy-metrics-daily.sh
+++ b/cron.d/cron.daily/galaxy-metrics-daily.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# exit on error
+set -e
+
+# create the db
+curl -i -XPOST "$INFLUX_URL/query" --data-urlencode "q=CREATE DATABASE $INFLUX_DB"
+
+data=$(mktemp --suffix .gxadmin)
+
+# send output of all commands to file
+{
+  gxadmin iquery users-count
+  gxadmin iquery collection-usage
+  gxadmin iquery ts-repos
+  gxadmin iquery tool-likely-broken
+  # Export all server statistics
+  gxadmin meta slurp-day $(date -d "$i days ago" "+%Y-%m-%d")
+} > "$data"
+
+# Ship to influxdb
+gxadmin meta influx-post "$INFLUX_DB" "$data"
+
+# Cleanup
+rm "$data"

--- a/cron.d/cron.daily/galaxy-metrics-daily.sh
+++ b/cron.d/cron.daily/galaxy-metrics-daily.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# exit on error
-set -e
-
 # create the db
 curl -i -XPOST "$INFLUX_URL/query" --data-urlencode "q=CREATE DATABASE $INFLUX_DB"
 

--- a/cron.d/cron.hourly/galaxy-metrics-hourly.sh
+++ b/cron.d/cron.hourly/galaxy-metrics-hourly.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# exit on error
-set -e
-
 # create the db
 curl -i -XPOST "$INFLUX_URL/query" --data-urlencode "q=CREATE DATABASE $INFLUX_DB"
 

--- a/cron.d/cron.hourly/galaxy-metrics-hourly.sh
+++ b/cron.d/cron.hourly/galaxy-metrics-hourly.sh
@@ -10,9 +10,6 @@ data=$(mktemp --suffix .gxadmin)
 
 # send output of all commands to file
 {
-  gxadmin iquery queue-overview --short-tool-id
-  gxadmin iquery queue-detail --all --seconds
-  gxadmin iquery jobs-queued
   gxadmin iquery upload-gb-in-past-hour
   gxadmin iquery users-count
   gxadmin iquery collection-usage
@@ -20,9 +17,6 @@ data=$(mktemp --suffix .gxadmin)
   gxadmin iquery user-disk-usage
   gxadmin iquery tool-errors
   gxadmin iquery tool-likely-broken
-  # Export all server statistics
-  gxadmin meta slurp-current
-  gxadmin meta slurp-day $(date -d "$i days ago" "+%Y-%m-%d")
 } > "$data"
 
 # Ship to influxdb

--- a/cron.d/cron.minute/galaxy-metrics-minute.sh
+++ b/cron.d/cron.minute/galaxy-metrics-minute.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# exit on error
-set -e
-
 data=$(mktemp --suffix .gxadmin)
 
 # send output of all commands to file

--- a/cron.d/cron.minute/galaxy-metrics-minute.sh
+++ b/cron.d/cron.minute/galaxy-metrics-minute.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# exit on error
+set -e
+
+data=$(mktemp --suffix .gxadmin)
+
+# send output of all commands to file
+{
+  gxadmin iquery queue-overview --short-tool-id
+  gxadmin iquery queue-detail --all --seconds
+  gxadmin iquery jobs-queued
+} > "$data"
+
+# Ship to influxdb
+gxadmin meta influx-post "$INFLUX_DB" "$data"
+
+# Cleanup
+rm "$data"

--- a/cron.d/cron.once/galaxy-metrics-once.sh
+++ b/cron.d/cron.once/galaxy-metrics-once.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# exit on error
+set -e
+
+# create the db
+curl -i -XPOST "$INFLUX_URL/query" --data-urlencode "q=CREATE DATABASE $INFLUX_DB"
+
+echo "Gathering one-time galaxy stats..."
+
+data=$(mktemp --suffix .gxadmin)
+
+# send output of all commands to file
+{
+  # Export all server statistics once on startup
+  gxadmin meta slurp-current --date
+} > "$data"
+
+# Ship to influxdb
+gxadmin meta influx-post "$INFLUX_DB" "$data"
+
+# Cleanup
+rm "$data"

--- a/cron.d/cron.once/galaxy-metrics-once.sh
+++ b/cron.d/cron.once/galaxy-metrics-once.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# exit on error
-set -e
-
 # create the db
 curl -i -XPOST "$INFLUX_URL/query" --data-urlencode "q=CREATE DATABASE $INFLUX_DB"
 

--- a/cron.d/cron.once/galaxy-metrics-once.sh
+++ b/cron.d/cron.once/galaxy-metrics-once.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
+echo "Gathering one-time galaxy stats..."
+
 # create the db
 curl -i -XPOST "$INFLUX_URL/query" --data-urlencode "q=CREATE DATABASE $INFLUX_DB"
-
-echo "Gathering one-time galaxy stats..."
 
 data=$(mktemp --suffix .gxadmin)
 

--- a/cron.d/crontab
+++ b/cron.d/crontab
@@ -1,4 +1,4 @@
-*/1 * * * * export $(cat /temp-ram-disk/container.env | xargs) && run-parts --report --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.minute > /var/log/cron.log 2>&1
-0 */1 * * * export $(cat /temp-ram-disk/container.env | xargs) && run-parts --report --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.hourly > /var/log/cron.log 2>&1
-0 2 */1 * * export $(cat /temp-ram-disk/container.env | xargs) && run-parts --report --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.daily > /var/log/cron.log 2>&1
-@reboot export $(cat /temp-ram-disk/container.env | xargs) && run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.once > /var/log/cron.log 2>&1
+* * * * * export $(cat /temp-ram-disk/container.env | xargs) && run-parts --report --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.minute >> /var/log/cron.log 2>&1
+0 * * * * export $(cat /temp-ram-disk/container.env | xargs) && run-parts --report --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.hourly >> /var/log/cron.log 2>&1
+0 2 * * * export $(cat /temp-ram-disk/container.env | xargs) && run-parts --report --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.daily >> /var/log/cron.log 2>&1
+@reboot export $(cat /temp-ram-disk/container.env | xargs) && run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.once >> /var/log/cron.log 2>&1

--- a/cron.d/crontab
+++ b/cron.d/crontab
@@ -1,0 +1,4 @@
+*/1 * * * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.minute >> /dev/stdout 2>&1
+0 */1 * * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.hourly >> /dev/stdout 2>&1
+0 2 */1 * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.daily >> /dev/stdout 2>&1
+@reboot run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.once >> /dev/stdout 2>&1

--- a/cron.d/crontab
+++ b/cron.d/crontab
@@ -1,4 +1,4 @@
-*/1 * * * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.minute > /dev/stdout 2>&1
-0 */1 * * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.hourly > /dev/stdout 2>&1
-0 2 */1 * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.daily > /dev/stdout 2>&1
-@reboot run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.once > /dev/stdout 2>&1
+*/1 * * * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.minute > /var/log/cron.log 2>&1
+0 */1 * * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.hourly > /var/log/cron.log 2>&1
+0 2 */1 * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.daily > //var/log/cron.log 2>&1
+@reboot run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.once > /var/log/cron.log 2>&1

--- a/cron.d/crontab
+++ b/cron.d/crontab
@@ -1,4 +1,4 @@
-*/1 * * * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.minute > /var/log/cron.log 2>&1
-0 */1 * * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.hourly > /var/log/cron.log 2>&1
-0 2 */1 * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.daily > //var/log/cron.log 2>&1
-@reboot run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.once > /var/log/cron.log 2>&1
+*/1 * * * * BASH_ENV=/temp-ram-disk/container.env run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.minute > /var/log/cron.log 2>&1
+0 */1 * * * BASH_ENV=/temp-ram-disk/container.env run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.hourly > /var/log/cron.log 2>&1
+0 2 */1 * * BASH_ENV=/temp-ram-disk/container.env run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.daily > //var/log/cron.log 2>&1
+@reboot BASH_ENV=/temp-ram-disk/container.env run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.once > /var/log/cron.log 2>&1

--- a/cron.d/crontab
+++ b/cron.d/crontab
@@ -1,4 +1,4 @@
-*/1 * * * * BASH_ENV=/temp-ram-disk/container.env run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.minute > /var/log/cron.log 2>&1
-0 */1 * * * BASH_ENV=/temp-ram-disk/container.env run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.hourly > /var/log/cron.log 2>&1
-0 2 */1 * * BASH_ENV=/temp-ram-disk/container.env run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.daily > //var/log/cron.log 2>&1
-@reboot BASH_ENV=/temp-ram-disk/container.env run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.once > /var/log/cron.log 2>&1
+*/1 * * * * export $(cat /temp-ram-disk/container.env | xargs) && run-parts --report --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.minute > /var/log/cron.log 2>&1
+0 */1 * * * export $(cat /temp-ram-disk/container.env | xargs) && run-parts --report --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.hourly > /var/log/cron.log 2>&1
+0 2 */1 * * export $(cat /temp-ram-disk/container.env | xargs) && run-parts --report --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.daily > /var/log/cron.log 2>&1
+@reboot export $(cat /temp-ram-disk/container.env | xargs) && run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.once > /var/log/cron.log 2>&1

--- a/cron.d/crontab
+++ b/cron.d/crontab
@@ -1,4 +1,4 @@
-*/1 * * * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.minute >> /dev/stdout 2>&1
-0 */1 * * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.hourly >> /dev/stdout 2>&1
-0 2 */1 * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.daily >> /dev/stdout 2>&1
-@reboot run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.once >> /dev/stdout 2>&1
+*/1 * * * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.minute > /dev/stdout 2>&1
+0 */1 * * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.hourly > /dev/stdout 2>&1
+0 2 */1 * * run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.daily > /dev/stdout 2>&1
+@reboot run-parts --report --exit-on-error --verbose --regex '.*.sh$' /opt/galaxy/cron.d/cron.once > /dev/stdout 2>&1


### PR DESCRIPTION
The current k8s cron job has to run in minute intervals, and possibly higher, which seems like too high a frequency for starting and stopping a container.

In addition, we need some queries to run at a different frequency, since they are very slow. Running all queries at the same time can completely tie up the database.

This PR turns the cronjob into a deployment running a crontab within docker, splitting the existing single cronjob to multiple.